### PR TITLE
Fix order-service config mount path

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -24,12 +24,9 @@ stringData:
 # Deployment — HERE IS THE BUG
 #
 # The app expects config at:  /app/config/db-credentials.json
-# The secret is mounted at:   /etc/secrets/db-credentials.json
+# The secret is mounted at:   /app/config/db-credentials.json
 #
-# This mismatch is realistic — it happens when:
-#   - A different team manages the Helm chart
-#   - Someone copies a template and changes the mountPath
-#   - The app was refactored but the manifest wasn't updated
+# This keeps the app and manifest aligned.
 ##############################################################
 apiVersion: apps/v1
 kind: Deployment
@@ -62,15 +59,12 @@ spec:
             - name: PORT
               value: "8080"
 
-          # --- Volume mount: WRONG PATH ---
-          # App reads from /app/config/ but we mount to /etc/secrets/
+          # --- Volume mount: aligned path ---
           volumeMounts:
             - name: db-config
-              mountPath: /etc/secrets        # <-- BUG: should be /app/config
+              mountPath: /app/config
               readOnly: true
 
-          # Liveness probe: checks if process is alive
-          # This PASSES because /healthz doesn't touch config
           livenessProbe:
             httpGet:
               path: /healthz
@@ -79,10 +73,6 @@ spec:
             periodSeconds: 10
             failureThreshold: 3
 
-          # Readiness probe: checks if pod can serve traffic
-          # This ALSO PASSES — same healthy endpoint
-          # A better probe would hit /api/orders, but many teams
-          # use the same endpoint for both. This is the trap.
           readinessProbe:
             httpGet:
               path: /readyz


### PR DESCRIPTION
This PR fixes the OrdersEndpointDown failure by aligning the Secret mount path with the application’s expected config path.

Summary:
- The app reads `/app/config/db-credentials.json`
- The deployment now mounts the Secret at `/app/config`

Result:
- Business endpoint requests should stop failing once the rollout picks up this manifest change.

Related alert:
- OrdersEndpointDown