### PR TITLE
Fix order-service config mount path for OrdersEndpointDown

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -21,15 +21,10 @@ stringData:
 
 ---
 ##############################################################
-# Deployment — HERE IS THE BUG
+# Deployment — fixed to match the app's expected config path
 #
 # The app expects config at:  /app/config/db-credentials.json
-# The secret is mounted at:   /etc/secrets/db-credentials.json
-#
-# This mismatch is realistic — it happens when:
-#   - A different team manages the Helm chart
-#   - Someone copies a template and changes the mountPath
-#   - The app was refactored but the manifest wasn't updated
+# The secret is now mounted at /app/config/db-credentials.json
 ##############################################################
 apiVersion: apps/v1
 kind: Deployment
@@ -61,16 +56,10 @@ spec:
           env:
             - name: PORT
               value: "8080"
-
-          # --- Volume mount: WRONG PATH ---
-          # App reads from /app/config/ but we mount to /etc/secrets/
           volumeMounts:
             - name: db-config
-              mountPath: /etc/secrets        # <-- BUG: should be /app/config
+              mountPath: /app/config
               readOnly: true
-
-          # Liveness probe: checks if process is alive
-          # This PASSES because /healthz doesn't touch config
           livenessProbe:
             httpGet:
               path: /healthz
@@ -78,11 +67,6 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 3
-
-          # Readiness probe: checks if pod can serve traffic
-          # This ALSO PASSES — same healthy endpoint
-          # A better probe would hit /api/orders, but many teams
-          # use the same endpoint for both. This is the trap.
           readinessProbe:
             httpGet:
               path: /readyz
@@ -90,7 +74,6 @@ spec:
             initialDelaySeconds: 3
             periodSeconds: 5
             failureThreshold: 3
-
           resources:
             requests:
               cpu: 50m


### PR DESCRIPTION
This PR fixes the `OrdersEndpointDown` incident by mounting `db-credentials` at `/app/config`, which matches the application’s expected config path.

Evidence from investigation:
- `demo/order-service` pods are Running but return 500s on `/api/orders`
- Logs show `failed to read config from /app/config/db-credentials.json: no such file or directory`
- Deployment previously mounted the Secret at `/etc/secrets`

Expected result:
- The app can read `db-credentials.json`
- Business endpoint requests should recover after rollout

Related alert:
- OrdersEndpointDown