### PR TITLE
Fix order-service db credentials mount path

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -21,15 +21,10 @@ stringData:
 
 ---
 ##############################################################
-# Deployment — HERE IS THE BUG
+# Deployment — fixed to match the app's expected config path
 #
 # The app expects config at:  /app/config/db-credentials.json
-# The secret is mounted at:   /etc/secrets/db-credentials.json
-#
-# This mismatch is realistic — it happens when:
-#   - A different team manages the Helm chart
-#   - Someone copies a template and changes the mountPath
-#   - The app was refactored but the manifest wasn't updated
+# The secret is now mounted at /app/config/db-credentials.json
 ##############################################################
 apiVersion: apps/v1
 kind: Deployment
@@ -61,16 +56,10 @@ spec:
           env:
             - name: PORT
               value: "8080"
-
-          # --- Volume mount: WRONG PATH ---
-          # App reads from /app/config/ but we mount to /etc/secrets/
           volumeMounts:
             - name: db-config
-              mountPath: /etc/secrets        # <-- BUG: should be /app/config
+              mountPath: /app/config
               readOnly: true
-
-          # Liveness probe: checks if process is alive
-          # This PASSES because /healthz doesn't touch config
           livenessProbe:
             httpGet:
               path: /healthz
@@ -78,11 +67,6 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 3
-
-          # Readiness probe: checks if pod can serve traffic
-          # This ALSO PASSES — same healthy endpoint
-          # A better probe would hit /api/orders, but many teams
-          # use the same endpoint for both. This is the trap.
           readinessProbe:
             httpGet:
               path: /readyz
@@ -90,7 +74,6 @@ spec:
             initialDelaySeconds: 3
             periodSeconds: 5
             failureThreshold: 3
-
           resources:
             requests:
               cpu: 50m

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -21,15 +21,10 @@ stringData:
 
 ---
 ##############################################################
-# Deployment — HERE IS THE BUG
+# Deployment — fixed mount path
 #
 # The app expects config at:  /app/config/db-credentials.json
-# The secret is mounted at:   /etc/secrets/db-credentials.json
-#
-# This mismatch is realistic — it happens when:
-#   - A different team manages the Helm chart
-#   - Someone copies a template and changes the mountPath
-#   - The app was refactored but the manifest wasn't updated
+# The secret is now mounted at /app/config/db-credentials.json
 ##############################################################
 apiVersion: apps/v1
 kind: Deployment
@@ -62,15 +57,11 @@ spec:
             - name: PORT
               value: "8080"
 
-          # --- Volume mount: WRONG PATH ---
-          # App reads from /app/config/ but we mount to /etc/secrets/
           volumeMounts:
             - name: db-config
-              mountPath: /etc/secrets        # <-- BUG: should be /app/config
+              mountPath: /app/config
               readOnly: true
 
-          # Liveness probe: checks if process is alive
-          # This PASSES because /healthz doesn't touch config
           livenessProbe:
             httpGet:
               path: /healthz
@@ -79,10 +70,6 @@ spec:
             periodSeconds: 10
             failureThreshold: 3
 
-          # Readiness probe: checks if pod can serve traffic
-          # This ALSO PASSES — same healthy endpoint
-          # A better probe would hit /api/orders, but many teams
-          # use the same endpoint for both. This is the trap.
           readinessProbe:
             httpGet:
               path: /readyz


### PR DESCRIPTION
Fixes the root cause of `OrdersEndpointDown`.

Problem:
- `order-service` expects `/app/config/db-credentials.json`
- the manifest mounted the secret at `/etc/secrets`

Change:
- mount the secret at `/app/config` so the file exists at the exact path the app reads

Incident issue: #8