### PR TITLE
Fix order-service config mount path

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -21,7 +21,15 @@ stringData:
 
 ---
 ##############################################################
-# Deployment — FIXED
+# Deployment — HERE IS THE BUG
+#
+# The app expects config at:  /app/config/db-credentials.json
+# The secret is mounted at:   /etc/secrets/db-credentials.json
+#
+# This mismatch is realistic — it happens when:
+#   - A different team manages the Helm chart
+#   - Someone copies a template and changes the mountPath
+#   - The app was refactored but the manifest wasn't updated
 ##############################################################
 apiVersion: apps/v1
 kind: Deployment
@@ -53,10 +61,16 @@ spec:
           env:
             - name: PORT
               value: "8080"
+
+          # --- Volume mount: WRONG PATH ---
+          # App reads from /app/config/ but we mount to /etc/secrets/
           volumeMounts:
             - name: db-config
-              mountPath: /app/config
+              mountPath: /app/config        # fixed: match application config path
               readOnly: true
+
+          # Liveness probe: checks if process is alive
+          # This PASSES because /healthz doesn't touch config
           livenessProbe:
             httpGet:
               path: /healthz
@@ -64,6 +78,11 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 3
+
+          # Readiness probe: checks if pod can serve traffic
+          # This ALSO PASSES — same healthy endpoint
+          # A better probe would hit /api/orders, but many teams
+          # use the same endpoint for both. This is the trap.
           readinessProbe:
             httpGet:
               path: /readyz
@@ -71,6 +90,7 @@ spec:
             initialDelaySeconds: 3
             periodSeconds: 5
             failureThreshold: 3
+
           resources:
             requests:
               cpu: 50m

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -21,15 +21,7 @@ stringData:
 
 ---
 ##############################################################
-# Deployment — HERE IS THE BUG
-#
-# The app expects config at:  /app/config/db-credentials.json
-# The secret is mounted at:   /etc/secrets/db-credentials.json
-#
-# This mismatch is realistic — it happens when:
-#   - A different team manages the Helm chart
-#   - Someone copies a template and changes the mountPath
-#   - The app was refactored but the manifest wasn't updated
+# Deployment — FIXED
 ##############################################################
 apiVersion: apps/v1
 kind: Deployment
@@ -61,16 +53,10 @@ spec:
           env:
             - name: PORT
               value: "8080"
-
-          # --- Volume mount: WRONG PATH ---
-          # App reads from /app/config/ but we mount to /etc/secrets/
           volumeMounts:
             - name: db-config
-              mountPath: /etc/secrets        # <-- BUG: should be /app/config
+              mountPath: /app/config
               readOnly: true
-
-          # Liveness probe: checks if process is alive
-          # This PASSES because /healthz doesn't touch config
           livenessProbe:
             httpGet:
               path: /healthz
@@ -78,11 +64,6 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 3
-
-          # Readiness probe: checks if pod can serve traffic
-          # This ALSO PASSES — same healthy endpoint
-          # A better probe would hit /api/orders, but many teams
-          # use the same endpoint for both. This is the trap.
           readinessProbe:
             httpGet:
               path: /readyz
@@ -90,7 +71,6 @@ spec:
             initialDelaySeconds: 3
             periodSeconds: 5
             failureThreshold: 3
-
           resources:
             requests:
               cpu: 50m


### PR DESCRIPTION
Fixes the OrdersEndpointDown incident by mounting the secret where the app expects it.

- App reads `/app/config/db-credentials.json`
- Deployment previously mounted the secret at `/etc/secrets`
- This PR aligns the mount path with the application path

References #13