### PR TITLE
Fix order-service config mount path for db credentials (follow-up)

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -21,15 +21,7 @@ stringData:
 
 ---
 ##############################################################
-# Deployment — HERE IS THE BUG
-#
-# The app expects config at:  /app/config/db-credentials.json
-# The secret is mounted at:   /etc/secrets/db-credentials.json
-#
-# This mismatch is realistic — it happens when:
-#   - A different team manages the Helm chart
-#   - Someone copies a template and changes the mountPath
-#   - The app was refactored but the manifest wasn't updated
+# Deployment — fixed config mount path
 ##############################################################
 apiVersion: apps/v1
 kind: Deployment
@@ -62,15 +54,12 @@ spec:
             - name: PORT
               value: "8080"
 
-          # --- Volume mount: WRONG PATH ---
-          # App reads from /app/config/ but we mount to /etc/secrets/
+          # Mount where the app expects to read the config file
           volumeMounts:
             - name: db-config
-              mountPath: /etc/secrets        # <-- BUG: should be /app/config
+              mountPath: /app/config
               readOnly: true
 
-          # Liveness probe: checks if process is alive
-          # This PASSES because /healthz doesn't touch config
           livenessProbe:
             httpGet:
               path: /healthz
@@ -79,10 +68,6 @@ spec:
             periodSeconds: 10
             failureThreshold: 3
 
-          # Readiness probe: checks if pod can serve traffic
-          # This ALSO PASSES — same healthy endpoint
-          # A better probe would hit /api/orders, but many teams
-          # use the same endpoint for both. This is the trap.
           readinessProbe:
             httpGet:
               path: /readyz


### PR DESCRIPTION
Follow-up fix for the still-firing OrdersEndpointDown incident.

- App reads `/app/config/db-credentials.json`
- Deployment was mounting the secret at `/etc/secrets`
- Mount the secret at `/app/config` so the app can find the file

References #17