### PR TITLE
Fix order-service config mount path mismatch

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -21,15 +21,7 @@ stringData:
 
 ---
 ##############################################################
-# Deployment — HERE IS THE BUG
-#
-# The app expects config at:  /app/config/db-credentials.json
-# The secret is mounted at:   /etc/secrets/db-credentials.json
-#
-# This mismatch is realistic — it happens when:
-#   - A different team manages the Helm chart
-#   - Someone copies a template and changes the mountPath
-#   - The app was refactored but the manifest wasn't updated
+# Deployment — fixed config mount path
 ##############################################################
 apiVersion: apps/v1
 kind: Deployment
@@ -61,16 +53,10 @@ spec:
           env:
             - name: PORT
               value: "8080"
-
-          # --- Volume mount: WRONG PATH ---
-          # App reads from /app/config/ but we mount to /etc/secrets/
           volumeMounts:
             - name: db-config
-              mountPath: /etc/secrets        # <-- BUG: should be /app/config
+              mountPath: /app/config
               readOnly: true
-
-          # Liveness probe: checks if process is alive
-          # This PASSES because /healthz doesn't touch config
           livenessProbe:
             httpGet:
               path: /healthz
@@ -78,11 +64,6 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 3
-
-          # Readiness probe: checks if pod can serve traffic
-          # This ALSO PASSES — same healthy endpoint
-          # A better probe would hit /api/orders, but many teams
-          # use the same endpoint for both. This is the trap.
           readinessProbe:
             httpGet:
               path: /readyz
@@ -90,7 +71,6 @@ spec:
             initialDelaySeconds: 3
             periodSeconds: 5
             failureThreshold: 3
-
           resources:
             requests:
               cpu: 50m
@@ -98,16 +78,12 @@ spec:
             limits:
               cpu: 200m
               memory: 128Mi
-
       volumes:
         - name: db-config
           secret:
             secretName: db-credentials
 
 ---
-##############################################################
-# Service — exposes the pods
-##############################################################
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
Fixes the mount-path mismatch causing `/api/orders` failures while health checks still pass.

- App reads `/app/config/db-credentials.json`
- Deployment was mounting the secret at `/etc/secrets`
- This change mounts the secret at `/app/config` so the app can find the config file

Closes #19